### PR TITLE
The RoomDB

### DIFF
--- a/lib/live_transcript/application.ex
+++ b/lib/live_transcript/application.ex
@@ -5,6 +5,7 @@ defmodule LiveTranscript.Application do
 
   def start(_type, _args) do
     children = [
+      LiveTranscript.RoomDB,
       LiveTranscriptWeb.Endpoint
     ]
 

--- a/lib/live_transcript/room.ex
+++ b/lib/live_transcript/room.ex
@@ -1,0 +1,4 @@
+defmodule LiveTranscript.Room do
+  @enforce_keys [:name]
+  defstruct [:name]
+end

--- a/lib/live_transcript/room_db.ex
+++ b/lib/live_transcript/room_db.ex
@@ -6,7 +6,7 @@ defmodule LiveTranscript.RoomDB do
     GenServer.call(room_db, {:create_room, room})
   end
 
-  def name_taken?(name, room_db \\ __MODULE__) do
+  def room_exists?(name, room_db \\ __MODULE__) do
     :ets.member(room_db, name)
   end
 

--- a/lib/live_transcript/room_db.ex
+++ b/lib/live_transcript/room_db.ex
@@ -1,0 +1,45 @@
+defmodule LiveTranscript.RoomDB do
+  use GenServer
+  alias LiveTranscript.Room
+
+  def create_room(room = %Room{name: name}, room_db \\ __MODULE__) when is_binary(name) do
+    GenServer.call(room_db, {:create_room, room})
+  end
+
+  def name_taken?(name, room_db \\ __MODULE__) do
+    :ets.member(room_db, name)
+  end
+
+  def init(opts) do
+    ets_options =
+      if(opts[:unnamed], do: [], else: [:named_table]) ++
+        [:set, :protected, read_concurrency: true]
+
+    table = :ets.new(__MODULE__, ets_options)
+    {:ok, %{table: table}}
+  end
+
+  def start_link(opts) do
+    genserver_options = if opts[:unnamed], do: [], else: [name: __MODULE__]
+    GenServer.start_link(__MODULE__, opts, genserver_options)
+  end
+
+  def handle_call(:get_table, _from, state) do
+    {:reply, state.table, state}
+  end
+
+  def handle_call({:create_room, room}, _from, state) do
+    response =
+      if :ets.insert_new(state.table, {room.name, room}) do
+        {:ok, room}
+      else
+        {:error, :name_taken}
+      end
+
+    {:reply, response, state}
+  end
+
+  def _get_table(room_db \\ __MODULE__) do
+    GenServer.call(room_db, :get_table)
+  end
+end

--- a/lib/live_transcript/room_db.ex
+++ b/lib/live_transcript/room_db.ex
@@ -6,6 +6,13 @@ defmodule LiveTranscript.RoomDB do
     GenServer.call(room_db, {:create_room, room})
   end
 
+  def get_room(name, room_db \\ __MODULE__) do
+    case :ets.lookup(room_db, name) do
+      [{^name, room}] -> {:ok, room}
+      _ -> {:error, :not_found}
+    end
+  end
+
   def room_exists?(name, room_db \\ __MODULE__) do
     :ets.member(room_db, name)
   end

--- a/test/live_transcript/room_db_test.exs
+++ b/test/live_transcript/room_db_test.exs
@@ -21,7 +21,6 @@ defmodule LiveTranscript.RoomDBTest do
     test "You can get a reference to a Room DB ets table", %{pid: pid} do
       table = RoomDB._get_table(pid)
       assert is_reference(table)
-      assert [] == :ets.tab2list(table)
     end
   end
 
@@ -39,7 +38,6 @@ defmodule LiveTranscript.RoomDBTest do
     test "you can create a room that has a unique name", %{pid: pid, table: table} do
       room = %Room{name: "test"}
       assert {:ok, room} = RoomDB.create_room(room, pid)
-      assert [{"test", ^room}] = :ets.tab2list(table)
     end
 
     test "trying to create a room with a name that is taken will result in an error", %{pid: pid} do
@@ -58,6 +56,18 @@ defmodule LiveTranscript.RoomDBTest do
       refute RoomDB.room_exists?("test", table)
       {:ok, _} = RoomDB.create_room(%Room{name: "test"}, pid)
       assert RoomDB.room_exists?("test", table)
+    end
+  end
+
+  describe "get_room/1" do
+    test "trying to get a room that doesn't exist is an error", %{table: table} do
+      assert {:error, :not_found} == RoomDB.get_room("test", table)
+    end
+
+    test "trying to get a room that exists brings back the room", %{pid: pid, table: table} do
+      room = %Room{name: "test"}
+      {:ok, _} = RoomDB.create_room(room, pid)
+      assert {:ok, ^room} = RoomDB.get_room("test", table)
     end
   end
 end

--- a/test/live_transcript/room_db_test.exs
+++ b/test/live_transcript/room_db_test.exs
@@ -49,15 +49,15 @@ defmodule LiveTranscript.RoomDBTest do
     end
   end
 
-  describe "name_taken?/1" do
+  describe "room_exists?/1" do
     test "with a fresh name is false", %{table: table} do
-      refute RoomDB.name_taken?("test", table)
+      refute RoomDB.room_exists?("test", table)
     end
 
     test "With a taken name is true", %{table: table, pid: pid} do
-      refute RoomDB.name_taken?("test", table)
+      refute RoomDB.room_exists?("test", table)
       {:ok, _} = RoomDB.create_room(%Room{name: "test"}, pid)
-      assert RoomDB.name_taken?("test", table)
+      assert RoomDB.room_exists?("test", table)
     end
   end
 end

--- a/test/live_transcript/room_db_test.exs
+++ b/test/live_transcript/room_db_test.exs
@@ -1,0 +1,63 @@
+defmodule LiveTranscript.RoomDBTest do
+  alias LiveTranscript.Room
+  alias LiveTranscript.RoomDB
+
+  use ExUnit.Case
+
+  setup do
+    {:ok, pid} = RoomDB.start_link(unnamed: true)
+    {:ok, %{pid: pid, table: RoomDB._get_table(pid)}}
+  end
+
+  test "You can start a RoomDB", %{pid: pid} do
+    assert Process.alive?(pid)
+  end
+
+  describe "_get_table/0 && _get_table/1" do
+    test "The name of the global table is the module name" do
+      assert RoomDB == RoomDB._get_table()
+    end
+
+    test "You can get a reference to a Room DB ets table", %{pid: pid} do
+      table = RoomDB._get_table(pid)
+      assert is_reference(table)
+      assert [] == :ets.tab2list(table)
+    end
+  end
+
+  describe "create_room/1" do
+    test "trying to create a room without a room struct + a string name key raises an error" do
+      [
+        fn -> RoomDB.create_room(%{}) end,
+        fn -> RoomDB.create_room(%{name: "test"}) end,
+        fn -> RoomDB.create_room(%Room{name: :a}) end,
+        fn -> RoomDB.create_room(%Room{name: 1}) end
+      ]
+      |> Enum.each(&assert_raise FunctionClauseError, &1)
+    end
+
+    test "you can create a room that has a unique name", %{pid: pid, table: table} do
+      room = %Room{name: "test"}
+      assert {:ok, room} = RoomDB.create_room(room, pid)
+      assert [{"test", ^room}] = :ets.tab2list(table)
+    end
+
+    test "trying to create a room with a name that is taken will result in an error", %{pid: pid} do
+      room = %Room{name: "test"}
+      assert {:ok, ^room} = RoomDB.create_room(room, pid)
+      assert {:error, :name_taken} = RoomDB.create_room(room, pid)
+    end
+  end
+
+  describe "name_taken?/1" do
+    test "with a fresh name is false", %{table: table} do
+      refute RoomDB.name_taken?("test", table)
+    end
+
+    test "With a taken name is true", %{table: table, pid: pid} do
+      refute RoomDB.name_taken?("test", table)
+      {:ok, _} = RoomDB.create_room(%Room{name: "test"}, pid)
+      assert RoomDB.name_taken?("test", table)
+    end
+  end
+end

--- a/test/live_transcript_web/views/error_view_test.exs
+++ b/test/live_transcript_web/views/error_view_test.exs
@@ -9,6 +9,7 @@ defmodule LiveTranscriptWeb.ErrorViewTest do
   end
 
   test "renders 500.html" do
-    assert render_to_string(LiveTranscriptWeb.ErrorView, "500.html", []) == "Internal Server Error"
+    assert render_to_string(LiveTranscriptWeb.ErrorView, "500.html", []) ==
+             "Internal Server Error"
   end
 end


### PR DESCRIPTION
The RoomDB will serve as the system wide source of truth of active rooms.

Some goals of the Rooms DB subsystem


- [x] We should be able to give out a unique room name. There should be no
collisions in the room names.
- [x] We should be able to quickly answer the question "Is this room name
taken?"

- [x] We should be able to retrieve a room by name

ETS was chosen because another project wide goal is few (no?)
outside dependencies. ETS is a fast simple choice to holding server wide
state. Currently the plan is to only support a single server running at
a time, which means ETS being an in memory DB isn't that big of a deal.
In the future it could be switched out to a more distributed data store.