### PR TITLE
Add a uuid to Rooms

### DIFF
--- a/lib/live_transcript/room.ex
+++ b/lib/live_transcript/room.ex
@@ -1,4 +1,8 @@
 defmodule LiveTranscript.Room do
-  @enforce_keys [:name]
-  defstruct [:name]
+  @enforce_keys [:name, :uuid]
+  defstruct [:name, :uuid]
+
+  def new(name: name) do
+    %__MODULE__{name: name, uuid: make_ref()}
+  end
 end

--- a/lib/live_transcript/room_db.ex
+++ b/lib/live_transcript/room_db.ex
@@ -2,7 +2,8 @@ defmodule LiveTranscript.RoomDB do
   use GenServer
   alias LiveTranscript.Room
 
-  def create_room(room = %Room{name: name}, room_db \\ __MODULE__) when is_binary(name) do
+  def create_room(name, room_db \\ __MODULE__) when is_binary(name) do
+    room = Room.new(name: name)
     GenServer.call(room_db, {:create_room, room})
   end
 

--- a/lib/live_transcript_web/controllers/room_controller.ex
+++ b/lib/live_transcript_web/controllers/room_controller.ex
@@ -1,6 +1,6 @@
 defmodule LiveTranscriptWeb.RoomController do
   use LiveTranscriptWeb, :controller
-  alias LiveTranscript.{Room, RoomDB}
+  alias LiveTranscript.RoomDB
 
   def new(conn, _params) do
     render(conn, "new.html")
@@ -17,7 +17,7 @@ defmodule LiveTranscriptWeb.RoomController do
   end
 
   def create(conn, %{"name" => name}) do
-    case RoomDB.create_room(%Room{name: name}, get_room_db()) do
+    case RoomDB.create_room(name, get_room_db()) do
       {:ok, room} ->
         redirect(conn, to: Routes.room_path(conn, :show, room.name))
 

--- a/test/live_transcript_web/controllers/room_controller_test.exs
+++ b/test/live_transcript_web/controllers/room_controller_test.exs
@@ -1,6 +1,6 @@
 defmodule LiveTranscriptWeb.RoomControllerTest do
   use LiveTranscriptWeb.ConnCase
-  alias LiveTranscript.{Room, RoomDB}
+  alias LiveTranscript.RoomDB
 
   test "GET /rooms/new", %{conn: conn} do
     conn = get(conn, "/rooms/new")
@@ -10,7 +10,7 @@ defmodule LiveTranscriptWeb.RoomControllerTest do
   describe "GET /rooms/:id" do
     test "With a real room returns the room", %{conn: conn} do
       name = unique_name()
-      RoomDB.create_room(%Room{name: name})
+      RoomDB.create_room(name)
       conn = get(conn, "/rooms/#{name}")
       assert html_response(conn, 200) =~ "Room #{name}"
     end
@@ -30,7 +30,7 @@ defmodule LiveTranscriptWeb.RoomControllerTest do
 
     test "With a taken name", %{conn: conn} do
       name = unique_name()
-      RoomDB.create_room(%Room{name: name})
+      RoomDB.create_room(name)
       conn = post(conn, "/rooms", %{name: name})
       assert html_response(conn, 302)
     end


### PR DESCRIPTION
This uuid will serve as a unique room identifier, this means that if a
room name gets recycled, any persistent references will not spill over.

An example, if I'm authorized to view room "test", and the server gets
reset, its important that I'm no longer able to access the room because
it could be owned by someone else now. For any persistent records like
cookies, the ref value should be used.

I'm experiementing with using erlang references as guids instead of the
more traditionall 128 binary strings that you see most places, I'll see
if it makes it easier or not

(It would be a pretty cool contribution to ELixir to have a Guid Module
to deal with 128 bit references)